### PR TITLE
Smooth switching between frequencies in generators

### DIFF
--- a/src/generator/SineGenerator.h
+++ b/src/generator/SineGenerator.h
@@ -101,4 +101,5 @@ class dibiff::generator::SineGenerator : public dibiff::generator::Generator {
         float frequency;
         int totalSamples;
         int currentSample;
+        float phase;
 };

--- a/src/generator/SquareGenerator.h
+++ b/src/generator/SquareGenerator.h
@@ -106,4 +106,5 @@ class dibiff::generator::SquareGenerator : public dibiff::generator::Generator {
         float frequency;
         int totalSamples;
         int currentSample;
+        float phase;
 };

--- a/src/generator/TriangleGenerator.h
+++ b/src/generator/TriangleGenerator.h
@@ -101,4 +101,5 @@ class dibiff::generator::TriangleGenerator : public dibiff::generator::Generator
         float frequency;
         int totalSamples;
         int currentSample;
+        float phase;
 };

--- a/src/midi/VoiceSelector.cpp
+++ b/src/midi/VoiceSelector.cpp
@@ -106,14 +106,10 @@ void dibiff::midi::VoiceSelector::processMidiMessage(std::vector<unsigned char> 
 
     if (type == 0x90 && velocity > 0) { // Note on
         /// Find the next available voice and assign the frequency
-        for (int i = 0; i < voices.size(); ++i) {
-            if (!voices[i].active) {
-                voices[i].frequency = frequency;
-                voices[i].active = true;
-                voices[i].midiMessage = message;
-                break;
-            }
-        }
+        voices[voiceIndex].frequency = frequency;
+        voices[voiceIndex].active = true;
+        voices[voiceIndex].midiMessage = message;
+        voiceIndex = (voiceIndex + 1) % voices.size();
     } else if (type == 0x80 || (type == 0x90 && velocity == 0)) { // Note off
         /// Find the voice with the matching frequency and deactivate it
         for (int i = 0; i < voices.size(); ++i) {

--- a/test/BabysFirstSynthTest.cpp
+++ b/test/BabysFirstSynthTest.cpp
@@ -12,12 +12,12 @@ int main() {
     params.blockSize = blockSize;
     params.sampleRate = sampleRate;
     params.midiPortNum = 0;
-    params.numVoices = 3;
-    params.gain = -6.0f;
+    params.numVoices = 16;
+    params.gain = 12.0f;
     params.attack = 0.1f;
     params.decay = 0.1f;
     params.sustain = 0.5f;
-    params.release = 1.0f;
+    params.release = 0.5f;
     params.modulationRate = 0.4f;
     params.modulationDepth = 2.0f;
     auto babysFirstSynth = graph.add(dibiff::synth::BabysFirstSynth::create(params));


### PR DESCRIPTION
#11 

- - - 

By tracking the phase, we can smoothly interpolate between two frequencies when switching, removing any discontinuities and preventing distortion.
