### PR TITLE
Making objects able to be not connected

### DIFF
--- a/src/dynamic/Compressor.cpp
+++ b/src/dynamic/Compressor.cpp
@@ -56,7 +56,14 @@ float dibiff::dynamic::Compressor::process(float sample) {
  * @details Processes a block of audio data
  */
 void dibiff::dynamic::Compressor::process() {
-    if (input->isReady()) {
+    if (!input->isConnected()) {
+        /// If no input is connected, just dump zeros into the output
+        std::vector<float> inData = *input->getData();
+        int inBlockSize = input->getBlockSize();
+        std::vector<float> out(inBlockSize, 0.0f);
+        output->setData(out, inBlockSize);
+    } else if (input->isReady()) {
+        /// If connected and ready, process the data
         std::vector<float> data = *input->getData();
         int blockSize = input->getBlockSize();
         Eigen::VectorXf x(blockSize), y(blockSize);
@@ -152,8 +159,10 @@ bool dibiff::dynamic::Compressor::isFinished() const {
  * @return True if the filter is ready to process, false otherwise
  */
 bool dibiff::dynamic::Compressor::isReadyToProcess() const {
-    // Check if input is connected
-    return input->isConnected() && input->isReady() && !processed;
+    if (!input->isConnected()) {
+        return true;
+    }
+    return input->isReady() && !processed;
 }
 /**
  * Create a new compressor object

--- a/src/dynamic/Envelope.cpp
+++ b/src/dynamic/Envelope.cpp
@@ -94,7 +94,13 @@ void dibiff::dynamic::Envelope::process() {
             noteOff();
         }
     }
-    if (input->isReady()) {
+    if (!input->isConnected()) {
+        /// If no input is connected, just dump zeros into the output
+        std::vector<float> inData = *input->getData();
+        int inBlockSize = input->getBlockSize();
+        std::vector<float> out(inBlockSize, 0.0f);
+        output->setData(out, inBlockSize);
+    } else if (input->isReady()) {
         std::vector<float> data = *input->getData();
         int blockSize = input->getBlockSize();
         Eigen::VectorXf x(blockSize), y(blockSize);
@@ -165,8 +171,10 @@ bool dibiff::dynamic::Envelope::isFinished() const {
  * @return True if the filter is ready to process, false otherwise
  */
 bool dibiff::dynamic::Envelope::isReadyToProcess() const {
-    // Check if input is connected
-    return input->isConnected() && input->isReady() && !processed;
+    if (!input->isConnected()) {
+        return true;
+    }
+    return input->isReady() && !processed;
 }
 /**
  * Create a new envelope object

--- a/src/dynamic/Expander.cpp
+++ b/src/dynamic/Expander.cpp
@@ -48,7 +48,12 @@ float dibiff::dynamic::Expander::process(float sample) {
  * @details Processes a block of audio data
  */
 void dibiff::dynamic::Expander::process() {
-    if (input->isReady()) {
+    if (!input->isConnected()) {
+        /// If no input is connected, just dump zeros into the output
+        std::vector<float> out(input->getBlockSize(), 0.0f);
+        output->setData(out, input->getBlockSize());
+        markProcessed();
+    } else if (input->isReady()) {
         std::vector<float> data = *input->getData();
         int blockSize = input->getBlockSize();
         Eigen::VectorXf x(blockSize), y(blockSize);
@@ -144,8 +149,10 @@ bool dibiff::dynamic::Expander::isFinished() const {
  * @return True if the filter is ready to process, false otherwise
  */
 bool dibiff::dynamic::Expander::isReadyToProcess() const {
-    // Check if input is connected
-    return input->isConnected() && input->isReady() && !processed;
+    if (!input->isConnected()) {
+        return true;
+    }
+    return input->isReady() && !processed;
 }
 /**
  * Create a new expander object

--- a/src/dynamic/Limiter.cpp
+++ b/src/dynamic/Limiter.cpp
@@ -55,7 +55,12 @@ float dibiff::dynamic::Limiter::process(float sample) {
  * @details Processes a block of audio data
  */
 void dibiff::dynamic::Limiter::process() {
-    if (input->isReady()) {
+    if (!input->isConnected()) {
+        /// If no input is connected, just dump zeros into the output
+        std::vector<float> out(input->getBlockSize(), 0.0f);
+        output->setData(out, input->getBlockSize());
+        markProcessed();
+    } else if (input->isReady()) {
         std::vector<float> data = *input->getData();
         int blockSize = input->getBlockSize();
         Eigen::VectorXf x(blockSize), y(blockSize);
@@ -150,8 +155,10 @@ bool dibiff::dynamic::Limiter::isFinished() const {
  * @return True if the filter is ready to process, false otherwise
  */
 bool dibiff::dynamic::Limiter::isReadyToProcess() const {
-    // Check if input is connected
-    return input->isConnected() && input->isReady() && !processed;
+    if (!input->isConnected()) {
+        return true;
+    }
+    return input->isReady() && !processed;
 }
 /**
  * Create a new limiter object

--- a/src/effect/Chorus.cpp
+++ b/src/effect/Chorus.cpp
@@ -58,7 +58,12 @@ float dibiff::effect::Chorus::process(float sample) {
  * @details Processes a block of audio data
  */
 void dibiff::effect::Chorus::process() {
-    if (input->isReady()) {
+    if (!input->isConnected()) {
+        /// If no input is connected, just dump zeros into the output
+        std::vector<float> out(input->getBlockSize(), 0.0f);
+        output->setData(out, input->getBlockSize());
+        markProcessed();
+    } else if (input->isReady()) {
         std::vector<float> data = *input->getData();
         int blockSize = input->getBlockSize();
         Eigen::VectorXf x(blockSize), y(blockSize);
@@ -117,8 +122,10 @@ bool dibiff::effect::Chorus::isFinished() const {
  * @return True if the filter is ready to process, false otherwise
  */
 bool dibiff::effect::Chorus::isReadyToProcess() const {
-    // Check if input is connected
-    return input->isConnected() && input->isReady() && !processed;
+    if (!input->isConnected()) {
+        return true;
+    }
+    return input->isReady() && !processed;
 }
 /**
  * Create a new chorus object

--- a/src/effect/Flanger.cpp
+++ b/src/effect/Flanger.cpp
@@ -54,7 +54,12 @@ float dibiff::effect::Flanger::process(float sample) {
  * @details Processes a block of audio data
  */
 void dibiff::effect::Flanger::process() {
-    if (input->isReady()) {
+    if (!input->isConnected()) {
+        /// If no input is connected, just dump zeros into the output
+        std::vector<float> out(input->getBlockSize(), 0.0f);
+        output->setData(out, input->getBlockSize());
+        markProcessed();
+    } else if (input->isReady()) {
         std::vector<float> data = *input->getData();
         int blockSize = input->getBlockSize();
         Eigen::VectorXf x(blockSize), y(blockSize);
@@ -113,8 +118,10 @@ bool dibiff::effect::Flanger::isFinished() const {
  * @return True if the filter is ready to process, false otherwise
  */
 bool dibiff::effect::Flanger::isReadyToProcess() const {
-    // Check if input is connected
-    return input->isConnected() && input->isReady() && !processed;
+    if (!input->isConnected()) {
+        return true;
+    }
+    return input->isReady() && !processed;
 }
 /**
  * Create a new flanger object

--- a/src/effect/Phaser.cpp
+++ b/src/effect/Phaser.cpp
@@ -64,7 +64,12 @@ float dibiff::effect::Phaser::process(float sample) {
  * @details Processes a block of audio data
  */
 void dibiff::effect::Phaser::process() {
-    if (input->isReady()) {
+    if (!input->isConnected()) {
+        /// If no input is connected, just dump zeros into the output
+        std::vector<float> out(input->getBlockSize(), 0.0f);
+        output->setData(out, input->getBlockSize());
+        markProcessed();
+    } else if (input->isReady()) {
         std::vector<float> data = *input->getData();
         int blockSize = input->getBlockSize();
         Eigen::VectorXf x(blockSize), y(blockSize);
@@ -127,8 +132,10 @@ bool dibiff::effect::Phaser::isFinished() const {
  * @return True if the filter is ready to process, false otherwise
  */
 bool dibiff::effect::Phaser::isReadyToProcess() const {
-    // Check if input is connected
-    return input->isConnected() && input->isReady() && !processed;
+    if (!input->isConnected()) {
+        return true;
+    }
+    return input->isReady() && !processed;
 }
 /**
  * Create a new phaser object

--- a/src/effect/Reverb.cpp
+++ b/src/effect/Reverb.cpp
@@ -61,7 +61,12 @@ float dibiff::effect::Reverb::process(float sample) {
  * @details Processes a block of audio data
  */
 void dibiff::effect::Reverb::process() {
-    if (input->isReady()) {
+    if (!input->isConnected()) {
+        /// If no input is connected, just dump zeros into the output
+        std::vector<float> out(input->getBlockSize(), 0.0f);
+        output->setData(out, input->getBlockSize());
+        markProcessed();
+    } else if (input->isReady()) {
         std::vector<float> audioData = *input->getData();
         int blockSize = input->getBlockSize();
         Eigen::VectorXf x(blockSize), y(blockSize);
@@ -125,8 +130,10 @@ bool dibiff::effect::Reverb::isFinished() const {
  * @return True if the filter is ready to process, false otherwise
  */
 bool dibiff::effect::Reverb::isReadyToProcess() const {
-    // Check if input is connected
-    return input->isConnected() && input->isReady() && !processed;
+    if (!input->isConnected()) {
+        return true;
+    }
+    return input->isReady() && !processed;
 }
 /**
  * Create a new reverb object

--- a/src/effect/Tremolo.cpp
+++ b/src/effect/Tremolo.cpp
@@ -46,7 +46,12 @@ float dibiff::effect::Tremolo::process(float sample) {
  * @details Processes a block of audio data
  */
 void dibiff::effect::Tremolo::process() {
-    if (input->isReady()) {
+    if (!input->isConnected()) {
+        /// If no input is connected, just dump zeros into the output
+        std::vector<float> out(input->getBlockSize(), 0.0f);
+        output->setData(out, input->getBlockSize());
+        markProcessed();
+    } else if (input->isReady()) {
         std::vector<float> audioData = *input->getData();
         int blockSize = input->getBlockSize();
         Eigen::VectorXf x(blockSize), y(blockSize);
@@ -98,8 +103,10 @@ bool dibiff::effect::Tremolo::isFinished() const {
  * @return True if the filter is ready to process, false otherwise
  */
 bool dibiff::effect::Tremolo::isReadyToProcess() const {
-    // Check if input is connected
-    return input->isConnected() && input->isReady() && !processed;
+    if (!input->isConnected()) {
+        return true;
+    }
+    return input->isReady() && !processed;
 }
 /**
  * Create a new tremolo object

--- a/src/effect/Vibrato.cpp
+++ b/src/effect/Vibrato.cpp
@@ -53,7 +53,12 @@ float dibiff::effect::Vibrato::process(float sample) {
  * @details Processes a block of audio data
  */
 void dibiff::effect::Vibrato::process() {
-    if (input->isReady()) {
+    if (!input->isConnected()) {
+        /// If no input is connected, just dump zeros into the output
+        std::vector<float> out(input->getBlockSize(), 0.0f);
+        output->setData(out, input->getBlockSize());
+        markProcessed();
+    } else if (input->isReady()) {
         std::vector<float> data = *input->getData();
         int blockSize = input->getBlockSize();
         Eigen::VectorXf x(blockSize), y(blockSize);
@@ -112,8 +117,10 @@ bool dibiff::effect::Vibrato::isFinished() const {
  * @return True if the filter is ready to process, false otherwise
  */
 bool dibiff::effect::Vibrato::isReadyToProcess() const {
-    // Check if input is connected
-    return input->isConnected() && input->isReady() && !processed;
+    if (!input->isConnected()) {
+        return true;
+    }
+    return input->isReady() && !processed;
 }
 /**
  * Create a new vibrato object

--- a/src/filter/AdaptiveFilter.cpp
+++ b/src/filter/AdaptiveFilter.cpp
@@ -51,7 +51,18 @@ float dibiff::filter::AdaptiveFilter::process(float sample, float reference) {
  * @details Processes a block of audio data
  */
 void dibiff::filter::AdaptiveFilter::process() {
-    if (input->isReady() && reference->isReady()) {
+    if (!input->isConnected()) {
+        /// If no input is connected, just dump zeros into the output
+        std::vector<float> inData = *input->getData();
+        int inBlockSize = input->getBlockSize();
+        std::vector<float> out(inBlockSize, 0.0f);
+        output->setData(out, inBlockSize);
+    } else if (!reference->isConnected()) {
+        /// If no reference is connected, just pass the input through
+        std::vector<float> inData = *input->getData();
+        int inBlockSize = input->getBlockSize();
+        output->setData(inData, inBlockSize);
+    } else if (input->isReady() && reference->isReady()) {
         std::vector<float> inData = *input->getData();
         std::vector<float> refData = *reference->getData();
         int inBlockSize = input->getBlockSize();
@@ -117,8 +128,12 @@ bool dibiff::filter::AdaptiveFilter::isFinished() const {
  * @return True if the filter is ready to process, false otherwise
  */
 bool dibiff::filter::AdaptiveFilter::isReadyToProcess() const {
-    // Check if input is connected
-    return input->isConnected() && input->isReady() && reference->isConnected() && reference->isReady() && !processed;
+        if (!reference->isConnected()) {
+        return input->isConnected() && input->isReady() && !processed;
+    } else if (!input->isConnected()) {
+        return true;
+    }
+    return input->isReady() && reference->isReady() && !processed;
 }
 /**
  * Create a new adaptive filter object

--- a/src/filter/DigitalBiquadFilter.cpp
+++ b/src/filter/DigitalBiquadFilter.cpp
@@ -61,7 +61,12 @@ float dibiff::filter::DigitalBiquadFilter::process(float sample) {
  * @details Processes a block of samples of audio data
  */
 void dibiff::filter::DigitalBiquadFilter::process() {
-    if (input->isReady()) {
+    if (!input->isConnected()) {
+        /// If no input is connected, just dump zeros into the output
+        std::vector<float> out(input->getBlockSize(), 0.0f);
+        output->setData(out, input->getBlockSize());
+        markProcessed();
+    } else if (input->isReady()) {
         std::vector<float> data = *input->getData();
         int blockSize = input->getBlockSize();
         Eigen::VectorXf x(blockSize), y(blockSize);
@@ -133,8 +138,10 @@ bool dibiff::filter::DigitalBiquadFilter::isFinished() const {
  * @return True if the filter is ready to process, false otherwise
  */
 bool dibiff::filter::DigitalBiquadFilter::isReadyToProcess() const {
-    // Check if input is connected
-    return input->isConnected() && input->isReady() && !processed;
+    if (!input->isConnected()) {
+        return true;
+    }
+    return input->isReady() && !processed;
 }
 /**
  * @brief Create a new filter object

--- a/src/gate/ExpanderGate.cpp
+++ b/src/gate/ExpanderGate.cpp
@@ -55,7 +55,12 @@ float dibiff::gate::ExpanderGate::process(float sample) {
  * @param blockSize The size of the block
  */
 void dibiff::gate::ExpanderGate::process() {
-    if (input->isReady()) {
+    if (!input->isConnected()) {
+        /// If no input is connected, just dump zeros into the output
+        std::vector<float> out(input->getBlockSize(), 0.0f);
+        output->setData(out, input->getBlockSize());
+        markProcessed();
+    } else if (input->isReady()) {
         std::vector<float> data = *input->getData();
         int blockSize = input->getBlockSize();
         Eigen::VectorXf x(blockSize), y(blockSize);
@@ -107,8 +112,10 @@ bool dibiff::gate::ExpanderGate::isFinished() const {
  * @return True if the filter is ready to process, false otherwise
  */
 bool dibiff::gate::ExpanderGate::isReadyToProcess() const {
-    // Check if input is connected
-    return input->isConnected() && input->isReady() && !processed;
+    if (!input->isConnected()) {
+        return true;
+    }
+    return input->isReady() && !processed;
 }
 /**
  * Create a new expander gate object

--- a/src/gate/Lookahead.cpp
+++ b/src/gate/Lookahead.cpp
@@ -62,7 +62,12 @@ float dibiff::gate::LookaheadGate::process(float sample) {
  * @param blockSize The size of the block
  */
 void dibiff::gate::LookaheadGate::process() {
-    if (input->isReady()) {
+    if (!input->isConnected()) {
+        /// If no input is connected, just dump zeros into the output
+        std::vector<float> out(input->getBlockSize(), 0.0f);
+        output->setData(out, input->getBlockSize());
+        markProcessed();
+    } else if (input->isReady()) {
         std::vector<float> data = *input->getData();
         int blockSize = input->getBlockSize();
         Eigen::VectorXf x(blockSize), y(blockSize);
@@ -122,8 +127,10 @@ bool dibiff::gate::LookaheadGate::isFinished() const {
  * @return True if the filter is ready to process, false otherwise
  */
 bool dibiff::gate::LookaheadGate::isReadyToProcess() const {
-    // Check if input is connected
-    return input->isConnected() && input->isReady() && !processed;
+    if (!input->isConnected()) {
+        return true;
+    }
+    return input->isReady() && !processed;
 }
 /**
  * Create a new lookahead gate object

--- a/src/gate/NoiseGate.cpp
+++ b/src/gate/NoiseGate.cpp
@@ -49,7 +49,12 @@ float dibiff::gate::NoiseGate::process(float sample) {
  * @details Processes a block of audio data
  */
 void dibiff::gate::NoiseGate::process() {
-    if (input->isReady()) {
+    if (!input->isConnected()) {
+        /// If no input is connected, just dump zeros into the output
+        std::vector<float> out(input->getBlockSize(), 0.0f);
+        output->setData(out, input->getBlockSize());
+        markProcessed();
+    } else if (input->isReady()) {
         std::vector<float> data = *input->getData();
         int blockSize = input->getBlockSize();
         Eigen::VectorXf x(blockSize), y(blockSize);
@@ -101,8 +106,10 @@ bool dibiff::gate::NoiseGate::isFinished() const {
  * @return True if the filter is ready to process, false otherwise
  */
 bool dibiff::gate::NoiseGate::isReadyToProcess() const {
-    // Check if input is connected
-    return input->isConnected() && input->isReady() && !processed;
+    if (!input->isConnected()) {
+        return true;
+    }
+    return input->isReady() && !processed;
 }
 /**
  * Create a new noise gate object

--- a/src/level/AutomaticGainControl.cpp
+++ b/src/level/AutomaticGainControl.cpp
@@ -53,7 +53,12 @@ float dibiff::level::AutomaticGainControl::process(float sample) {
  * @details Processes a block of audio data
  */
 void dibiff::level::AutomaticGainControl::process() {
-    if (input->isReady()) {
+    if (!input->isConnected()) {
+        /// If no input is connected, just dump zeros into the output
+        std::vector<float> out(input->getBlockSize(), 0.0f);
+        output->setData(out, input->getBlockSize());
+        markProcessed();
+    } else if (input->isReady()) {
         std::vector<float> data = *input->getData();
         int blockSize = input->getBlockSize();
         Eigen::VectorXf x(blockSize), y(blockSize);
@@ -106,8 +111,10 @@ bool dibiff::level::AutomaticGainControl::isFinished() const {
  * @return True if the filter is ready to process, false otherwise
  */
 bool dibiff::level::AutomaticGainControl::isReadyToProcess() const {
-    // Check if input is connected
-    return input->isConnected() && input->isReady() && !processed;
+    if (!input->isConnected()) {
+        return true;
+    }
+    return input->isReady() && !processed;
 }
 /**
  * Create a new AGC object

--- a/src/level/Gain.cpp
+++ b/src/level/Gain.cpp
@@ -35,7 +35,12 @@ float dibiff::level::Gain::process(float sample) {
 void dibiff::level::Gain::process() {
     /// Update value
     value = std::pow(10.0f, valuedB / 20.0f);
-    if (input->isReady()) {
+    if (!input->isConnected()) {
+        /// If no input is connected, just dump zeros into the output
+        std::vector<float> out(input->getBlockSize(), 0.0f);
+        output->setData(out, input->getBlockSize());
+        markProcessed();
+    } else if (input->isReady()) {
         std::vector<float> audioData = *input->getData();
         int blockSize = input->getBlockSize();
         Eigen::VectorXf x(blockSize), y(blockSize);
@@ -80,8 +85,10 @@ bool dibiff::level::Gain::isFinished() const {
  * @return True if the filter is ready to process, false otherwise
  */
 bool dibiff::level::Gain::isReadyToProcess() const {
-    // Check if input is connected
-    return input->isConnected() && input->isReady() && !processed;
+    if (!input->isConnected()) {
+        return true;
+    }
+    return input->isReady() && !processed;
 }
 /**
  * Create a new gain object

--- a/src/sink/GraphSink.cpp
+++ b/src/sink/GraphSink.cpp
@@ -19,7 +19,12 @@ void dibiff::sink::GraphSink::initialize() {
 }
 
 void dibiff::sink::GraphSink::process() {
-    if (input->isReady()) {
+    if (!input->isConnected()) {
+        /// Fill ring buffer with zeros
+        std::vector<float> zeros(blockSize, 0.0f);
+        ringBuffer->write(zeros.data(), blockSize);
+        markProcessed();
+    } else if (input->isReady()) {
         auto audioData = input->getData();
         int blockSize = input->getBlockSize();
         /// Add the audioData to the ring buffer
@@ -45,7 +50,10 @@ bool dibiff::sink::GraphSink::isFinished() const {
 }
 
 bool dibiff::sink::GraphSink::isReadyToProcess() const {
-    return input->isConnected() && input->isReady() && !processed;
+    if (!input->isConnected()) {
+        return true;
+    }
+    return input->isReady() && !processed;
 }
 
 std::shared_ptr<dibiff::sink::GraphSink> dibiff::sink::GraphSink::create(int rate, int blockSize) {

--- a/src/sink/WavWriter.cpp
+++ b/src/sink/WavWriter.cpp
@@ -39,7 +39,10 @@ dibiff::sink::WavWriter::~WavWriter() {
  * @details Processes a block of audio data
  */
 void dibiff::sink::WavWriter::process() {
-    if (input->isReady()) {
+    if (!input->isConnected()) {
+        /// Don't do anything if the input is not connected
+        markProcessed();
+    } else if (input->isReady()) {
         auto audioData = input->getData();
         int blockSize = input->getBlockSize();
         /// Also write the audioData to the .wav file
@@ -78,7 +81,10 @@ bool dibiff::sink::WavWriter::isFinished() const {
  * @return True if the WAV sink is ready to process, false otherwise
  */
 bool dibiff::sink::WavWriter::isReadyToProcess() const {
-    return input->isConnected() && input->isReady() && !processed;
+    if (!input->isConnected()) {
+        return true;
+    }
+    return input->isReady() && !processed;
 }
 /**
  * @brief Finalize the WAV header

--- a/src/time/Delay.cpp
+++ b/src/time/Delay.cpp
@@ -38,7 +38,12 @@ float dibiff::time::Delay::process(float sample) {
  * @details Processes a block of audio data
  */
 void dibiff::time::Delay::process() {
-    if (input->isReady()) {
+    if (!input->isConnected()) {
+        /// If no input is connected, just dump zeros into the output
+        std::vector<float> out(input->getBlockSize(), 0.0f);
+        output->setData(out, input->getBlockSize());
+        markProcessed();
+    } else if (input->isReady()) {
         std::vector<float> data = *input->getData();
         int blockSize = input->getBlockSize();
         Eigen::VectorXf x(blockSize), y(blockSize);
@@ -97,8 +102,10 @@ bool dibiff::time::Delay::isFinished() const {
  * @return True if the filter is ready to process, false otherwise
  */
 bool dibiff::time::Delay::isReadyToProcess() const {
-    // Check if input is connected
-    return input->isConnected() && input->isReady() && !processed;
+    if (!input->isConnected()) {
+        return true;
+    }
+    return input->isReady() && !processed;
 }
 /**
  * Create a new delay object


### PR DESCRIPTION
When an `AudioObject`'s input is not connected, we send zero's to the output instead of pausing. 